### PR TITLE
Explicitly specify utf-8 charset

### DIFF
--- a/src/alert.js
+++ b/src/alert.js
@@ -353,6 +353,7 @@ module.exports = class Alert {
 		let html = String.raw`
     <html>
       <head>
+      	<meta charset="utf-8">
 		<script type="text/javascript"><@insert-swal-lib@></script>
 		<style>.noselect{-webkit-touch-callout:none;user-select:none;-webkit-user-select:none;-webkit-app-region:no-drag}.no-drag{-webkit-app-region:no-drag}.border-radius-0{border-radius:0}</style>
         <style>.noscrollbar{overflow-y: hidden !important;}</style>


### PR DESCRIPTION
This PR fixes the display of text (for example, Cyrillic) in the alert window.

Before:
<img width="512" alt="Screenshot 2021-12-16 at 00 02 49" src="https://user-images.githubusercontent.com/4710207/146266496-299503dd-4a1a-4412-b83d-8dca00d40152.png">
After:
<img width="512" alt="Screenshot 2021-12-16 at 00 03 42" src="https://user-images.githubusercontent.com/4710207/146266519-88503781-377f-4c6e-a674-acd81adf6446.png">

